### PR TITLE
Correção na renderizão do Loader e refatorando as condições do component de Button

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -77,13 +77,13 @@ export const Button: FC<ButtonProps> = ({
   icon,
   ...props
 }) => {
+  const showShimmer = !icon && loading && shimmer
+  const showButtonLoader = !icon && loading
   return (
-    // @ts-expect-error
-    <>
-      {icon ? (
+
         // @ts-expect-error
         <ButtonContainer
-          btnIcon
+          btnIcon={!!icon}
           chip={chip}
           medium={!small && !large}
           fullWidth={fullWidth}
@@ -114,54 +114,22 @@ export const Button: FC<ButtonProps> = ({
           noBorder={noBorder}
           {...props}
         >
-          {children}
-          {icon}
-        </ButtonContainer>
-      ) : (
-        // @ts-expect-error
-        <ButtonContainer
-          chip={chip}
-          medium={!small && !large}
-          fullWidth={fullWidth}
-          block={block}
-          compact={compact}
-          dashed={dashed}
-          disabled={disabled}
-          inverse={inverse}
-          grouped={grouped}
-          groupedFirst={groupedFirst}
-          groupedLast={groupedLast}
-          large={large}
-          mono={mono}
-          noSpacing={noSpacing}
-          soft={soft}
-          primary={primary}
-          rectangular={rectangular}
-          removeSideSpacing={removeSideSpacing}
-          secondary={secondary}
-          shade={shade}
-          short={short}
-          simple={simple}
-          small={small}
-          tall={tall}
-          onClick={onClick}
-          transparent={transparent}
-          underlined={underlined}
-          noBorder={noBorder}
-          {...props}
-        >
-          {loading && shimmer && (
+          {showShimmer && (
             // @ts-expect-error
             <WrapperShimmer>
               {/** @ts-expect-error */}
               <Shimmer height="100%" width="100%" />
             </WrapperShimmer>
           )}
-          {/** @ts-expect-error */}
+          {icon && children ? (children) : (
+          /** @ts-expect-error */
           <Content contentLoading={loading} contentFullWidth={fullWidth}>
             {children}
-          </Content>
-          {loading && (
+          </Content>)
+          }
+
+          {icon && icon}
+          {showButtonLoader && (
             // @ts-expect-error
             <ButtonLoader>
               {!shimmer && (
@@ -176,8 +144,6 @@ export const Button: FC<ButtonProps> = ({
             </ButtonLoader>
           )}
         </ButtonContainer>
-      )}
-    </>
   );
 };
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -63,7 +63,7 @@ export const Button: FC<ButtonProps> = ({
   simple,
   soft,
   chip,
-  primary,
+  primary = false,
   rectangular,
   removeSideSpacing,
   secondary,
@@ -83,7 +83,7 @@ export const Button: FC<ButtonProps> = ({
 
         // @ts-expect-error
         <ButtonContainer
-          btnIcon={!!icon}
+          btnIcon={icon}
           chip={chip}
           medium={!small && !large}
           fullWidth={fullWidth}
@@ -145,8 +145,4 @@ export const Button: FC<ButtonProps> = ({
           )}
         </ButtonContainer>
   );
-};
-
-Button.defaultProps = {
-  primary: false,
 };

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -17,16 +17,18 @@ export const Loader: React.FC<LoaderProps> = ({
 }) => (
   // @ts-expect-error TS(17004): Cannot use JSX unless the '--jsx' flag is provided... Remove this comment to see the full error message
   <LoaderStyles>
-    // @ts-expect-error TS(17004): Cannot use JSX unless the '--jsx' flag is provided... Remove this comment to see the full error message
-    <LoaderBall
+{    
+  // @ts-expect-error TS(17004): Cannot use JSX unless the '--jsx' flag is provided... Remove this comment to see the full error message
+}    <LoaderBall
       mono={mono}
       large={large}
       small={small}
       primary={primary}
       secondary={secondary}
     />
-    // @ts-expect-error TS(17004): Cannot use JSX unless the '--jsx' flag is provided... Remove this comment to see the full error message
-    <LoaderBall
+{    
+  // @ts-expect-error TS(17004): Cannot use JSX unless the '--jsx' flag is provided... Remove this comment to see the full error message
+}    <LoaderBall
       second
       mono={mono}
       small={small}
@@ -34,8 +36,9 @@ export const Loader: React.FC<LoaderProps> = ({
       primary={primary}
       secondary={secondary}
     />
-    // @ts-expect-error TS(17004): Cannot use JSX unless the '--jsx' flag is provided... Remove this comment to see the full error message
-    <LoaderBall
+{    
+  // @ts-expect-error TS(17004): Cannot use JSX unless the '--jsx' flag is provided... Remove this comment to see the full error message
+}    <LoaderBall
       third
       mono={mono}
       small={small}


### PR DESCRIPTION
Ao clonar o repositório e abrir o Storybook, percebi que o componente de Loader estava renderizando o comentário "@ts-expect-error" em vez de renderizar o componente. Para resolver isso, adicionei chaves ao redor do comentário, permitindo assim o acesso ao JavaScript após o retorno da função.

Além disso, notei que era possível tornar o código do componente de Button mais legível. Isso poderia ser feito ao dividir trechos menores de condição e mover essas condições para constantes com nomes descritivos. Isso torna o código mais compreensível e facilita a manutenção.